### PR TITLE
Allow running the code in online playground

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - command: >
+      cd Java\ 8\ Streams &&
+      gp open JavaStreams.java &&
+      javac JavaStreams.java &&
+      java JavaStreams

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ https://www.youtube.com/user/joejamesusa
 and are mainly intended for educational purposes.
 You are invited to subscribe to my video channel, and to download and use any code in 
 this Java repository, according to the MIT License. 
+You can also play with the code online by opening this repository in Gitpod like so,
+https://gitpod.io/#https://github.com/joeyajames/Java
 Feel free to post any comments on my YouTube channel.
 
 Joe James.


### PR DESCRIPTION
Hi @joeyajames 👋 

I work on gitpod.io, an online development environment for GitHub, and I thought your viewers might be interested in having a way to edit & run your code online, without having to install anything on their computer.

In this Pull Request, I've configured Gitpod to:
- go into the `Java 8 Streams` directory
- open `JavaStreams.java` in the Editor
- compile and run this file in the Terminal

You can try this configuration by following this link (using my fork):
https://gitpod.io/#https://github.com/jankeromnes/Java

Here is what it will look like:
<img width="1552" alt="Screenshot 2019-07-25 at 11 06 42" src="https://user-images.githubusercontent.com/599268/61861601-93ef3680-aecc-11e9-9e0a-b72ddfaab6bb.png">
Please let me know what you think. 🙂